### PR TITLE
Revert "chore(docs): minor update to formatting of API link in README…

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The Finch Kotlin SDK is similar to the Finch Java SDK but with minor differences
 
 ## Documentation
 
-The REST API documentation can be found on [developer.tryfinch.com](https://developer.tryfinch.com/).
+The REST API documentation can be found [in the Finch Documentation Center](https://developer.tryfinch.com/).
 
 ---
 


### PR DESCRIPTION
… (#185)"

This reverts commit 36d3dec01c3bf63b9c38d219bf36a959357c3302.

This preserves the custom wording this repo is using for linking to the API Documentation.