### PR TITLE
fix(api): mark redirect_uri as optional for getAccessToken helper

### DIFF
--- a/finch-kotlin-core/src/main/kotlin/com/tryfinch/api/client/FinchClient.kt
+++ b/finch-kotlin-core/src/main/kotlin/com/tryfinch/api/client/FinchClient.kt
@@ -34,7 +34,7 @@ interface FinchClient {
         clientId: String,
         clientSecret: String,
         code: String,
-        redirectUri: String
+        redirectUri: String?
     ): String
 
     fun getAuthUrl(products: String, redirectUri: String, sandbox: Boolean): String
@@ -45,7 +45,7 @@ interface FinchClient {
         @JsonProperty("client_id") val clientId: String,
         @JsonProperty("client_secret") val clientSecret: String,
         @JsonProperty("code") val code: String,
-        @JsonProperty("redirect_uri") val redirectUri: String,
+        @JsonProperty("redirect_uri") val redirectUri: String?,
     )
 
     private data class GetAccessTokenResponse(

--- a/finch-kotlin-core/src/main/kotlin/com/tryfinch/api/client/FinchClientAsync.kt
+++ b/finch-kotlin-core/src/main/kotlin/com/tryfinch/api/client/FinchClientAsync.kt
@@ -34,7 +34,7 @@ interface FinchClientAsync {
         clientId: String,
         clientSecret: String,
         code: String,
-        redirectUri: String
+        redirectUri: String?
     ): String
 
     suspend fun getAuthUrl(products: String, redirectUri: String, sandbox: Boolean): String
@@ -45,7 +45,7 @@ interface FinchClientAsync {
         @JsonProperty("client_id") val clientId: String,
         @JsonProperty("client_secret") val clientSecret: String,
         @JsonProperty("code") val code: String,
-        @JsonProperty("redirect_uri") val redirectUri: String,
+        @JsonProperty("redirect_uri") val redirectUri: String?,
     )
 
     private data class GetAccessTokenResponse(

--- a/finch-kotlin-core/src/main/kotlin/com/tryfinch/api/client/FinchClientAsyncImpl.kt
+++ b/finch-kotlin-core/src/main/kotlin/com/tryfinch/api/client/FinchClientAsyncImpl.kt
@@ -75,7 +75,7 @@ constructor(
         clientId: String,
         clientSecret: String,
         code: String,
-        redirectUri: String
+        redirectUri: String?
     ): String {
         if (clientOptions.clientId == null) {
             throw FinchException("clientId must be set in order to call getAccessToken")
@@ -140,7 +140,7 @@ constructor(
         @JsonProperty("client_id") val clientId: String,
         @JsonProperty("client_secret") val clientSecret: String,
         @JsonProperty("code") val code: String,
-        @JsonProperty("redirect_uri") val redirectUri: String,
+        @JsonProperty("redirect_uri") val redirectUri: String?,
     )
 
     private data class GetAccessTokenResponse(

--- a/finch-kotlin-core/src/main/kotlin/com/tryfinch/api/client/FinchClientImpl.kt
+++ b/finch-kotlin-core/src/main/kotlin/com/tryfinch/api/client/FinchClientImpl.kt
@@ -73,7 +73,7 @@ constructor(
         clientId: String,
         clientSecret: String,
         code: String,
-        redirectUri: String
+        redirectUri: String?
     ): String {
         if (clientOptions.clientId == null) {
             throw FinchException("clientId must be set in order to call getAccessToken")
@@ -134,7 +134,7 @@ constructor(
         @JsonProperty("client_id") val clientId: String,
         @JsonProperty("client_secret") val clientSecret: String,
         @JsonProperty("code") val code: String,
-        @JsonProperty("redirect_uri") val redirectUri: String,
+        @JsonProperty("redirect_uri") val redirectUri: String?,
     )
 
     private data class GetAccessTokenResponse(

--- a/finch-kotlin-core/src/test/kotlin/com/tryfinch/api/client/FinchClientAsyncTest.kt
+++ b/finch-kotlin-core/src/test/kotlin/com/tryfinch/api/client/FinchClientAsyncTest.kt
@@ -44,13 +44,13 @@ class FinchClientAsyncTest {
         )
 
         assertThat(
-            client.getAccessToken(
-                "our-client-id",
-                "our-client-secret",
-                "finch-auth-code",
-                "our-redirect-uri"
+                client.getAccessToken(
+                    "our-client-id",
+                    "our-client-secret",
+                    "finch-auth-code",
+                    "our-redirect-uri"
+                )
             )
-        )
             .isEqualTo(expectedToken)
     }
 
@@ -68,8 +68,8 @@ class FinchClientAsyncTest {
         )
 
         assertThat(
-            client.getAccessToken("our-client-id", "our-client-secret", "finch-auth-code", null)
-        )
+                client.getAccessToken("our-client-id", "our-client-secret", "finch-auth-code", null)
+            )
             .isEqualTo(expectedToken)
     }
 }

--- a/finch-kotlin-core/src/test/kotlin/com/tryfinch/api/client/FinchClientAsyncTest.kt
+++ b/finch-kotlin-core/src/test/kotlin/com/tryfinch/api/client/FinchClientAsyncTest.kt
@@ -13,7 +13,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
 @WireMockTest
-class FinchClientTest {
+class FinchClientAsyncTest {
     private lateinit var client: FinchClient
 
     @BeforeEach

--- a/finch-kotlin-core/src/test/kotlin/com/tryfinch/api/client/FinchClientTest.kt
+++ b/finch-kotlin-core/src/test/kotlin/com/tryfinch/api/client/FinchClientTest.kt
@@ -44,13 +44,13 @@ class FinchClientTest {
         )
 
         assertThat(
-            client.getAccessToken(
-                "our-client-id",
-                "our-client-secret",
-                "finch-auth-code",
-                "our-redirect-uri"
+                client.getAccessToken(
+                    "our-client-id",
+                    "our-client-secret",
+                    "finch-auth-code",
+                    "our-redirect-uri"
+                )
             )
-        )
             .isEqualTo(expectedToken)
     }
 
@@ -68,8 +68,8 @@ class FinchClientTest {
         )
 
         assertThat(
-            client.getAccessToken("our-client-id", "our-client-secret", "finch-auth-code", null)
-        )
+                client.getAccessToken("our-client-id", "our-client-secret", "finch-auth-code", null)
+            )
             .isEqualTo(expectedToken)
     }
 }


### PR DESCRIPTION
- Marks this arg as optional
- Adds tests for this function
- Exact same changes as on Java here: https://github.com/Finch-API/finch-api-java/pull/260